### PR TITLE
fix(vue): support dots in component names

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -117,7 +117,7 @@ static void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
 
 static String scan_tag_name(TSLexer *lexer) {
     String tag_name = array_new();
-    while (iswalnum(lexer->lookahead) || lexer->lookahead == '-' || lexer->lookahead == ':') {
+    while (iswalnum(lexer->lookahead) || lexer->lookahead == '-' || lexer->lookahead == ':' || lexer->lookahead == '.') {
         array_push(&tag_name, towupper(lexer->lookahead));
         advance(lexer);
     }

--- a/test/corpus/spec.txt
+++ b/test/corpus/spec.txt
@@ -464,3 +464,28 @@ Shorthands - v-on Shorthand (https://vuejs.org/v2/guide/syntax.html#v-on-Shortha
         (tag_name)))
     (end_tag
       (tag_name))))
+
+===========================================
+Elements - Element names with a dot in them
+===========================================
+
+<template>
+
+<Hello.World> ... </Hello.World>
+
+</template>
+
+--------------------------------------------------------------------------------
+
+(document
+  (template_element
+    (start_tag
+      (tag_name))
+    (element
+      (start_tag
+        (tag_name))
+      (text)
+      (end_tag
+        (tag_name)))
+    (end_tag
+      (tag_name))))


### PR DESCRIPTION
This changes the `tag_name` parsing to allow a dot in the name. So, this will be fixed for both start tag and end tags.

Added a test that previously failed for this case:

```vue
<template>
    <Hello.World> ... </Hello.World>
</template>
```

Which was previously parsed as

```
(document
  (template_element
    (start_tag
      (tag_name))
    (element
      (start_tag
        (tag_name)
        (directive_attribute
          (directive_value)))
      (text)
      (end_tag
        (tag_name)
        (ERROR
          (UNEXPECTED 'W'))))
    (end_tag
      (tag_name))))
```

This is the same problem as described in #3 but I don't think the existing PR fixes the problem correctly.

After this change, the whole "Hello.World" part is parsed as `tag_name`.

Running `npm run build` makes some changes in `array.h`, but they don't seem relevant at first glance. Let me know if I should include those.

Fixes #3